### PR TITLE
Feat/bioinfo 22 add step to remove variants not passing filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### `Changed`
+- [#2](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/2) by default, only includes variants with FILTER column value of PASS.
+
 ## [v1.1] - 2024-08-21
 
 ### `Added`
@@ -17,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Samplesheet input method
 - Schema_input.json fields
-- [#1](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/1) invoke sample_preprocessing.py script throug:x!h binary modules feature
+- [#1](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/1) invoke sample_preprocessing.py script through binary modules feature
 
 ### `Fixed`
 - [#1](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/1) fix typo for parameter clustering_algorithm in schema

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You can customize how the clustering is made by specifying some parameters to GA
 Additionally you can pass extra args to GATK SVCluster by specifying the **task.ext.args** parameter.
 To know how to use the **task.ext.args** refer to the NextFlow documention. To know more about additional SVCluster parameters refer to SVCluster on GATK website.
 
+By default, only the variants with a FILTER column value of `PASS` are considered; others are ignored. You can disable this behavior by setting the `include_only_pass_variants` parameter to `false`.
+
 ## Credits
 
 ferlab/svclustering was originally written by David Morais.
@@ -105,7 +107,7 @@ Alexandre Dione
 
 Damien Geneste
 
-Lysisane Bouchard
+Lysiane Bouchard
 
 ## Contributions and Support
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,4 +18,14 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
+    withName: FILTER {
+        def args_list =  [
+            "-f PASS",
+            "-Oz"
+        ]
+        ext.args = args_list.join(" ")
+        ext.prefix = {"${meta.sample}.filtered"}
+        tag = {"Filter ${meta.sample}"}
+    }
+
 }

--- a/modules.json
+++ b/modules.json
@@ -3,6 +3,15 @@
   "homePage": "https://github.com/ferlab/svclustering",
   "repos": {
     "https://github.com/nf-core/modules.git": {
+      "modules": {
+        "nf-core": {
+          "bcftools/view": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          }
+        }
+      },
       "subworkflows": {
         "nf-core": {
           "utils_nextflow_pipeline": {

--- a/modules/local/preprocessing/preprocessing.nf
+++ b/modules/local/preprocessing/preprocessing.nf
@@ -31,5 +31,34 @@ process PREPROCESSING {
     END_VERSIONS
     
     """
-    
+
+    stub:
+    def sample_ids = samples.join(' ')
+    def vcf_paths  = vcfs.join(' ') 
+    """
+    # To make this stub realist, we verify that the input vcf paths exists
+    for vcf_path in $vcf_paths; do
+        if [ ! -f \$vcf_path ]; then
+            echo "ERROR: VCF file \$vcf_path does not exist"
+            exit 1
+        fi
+    done
+
+    # Create empty output files
+    for sample_id in $sample_ids; do
+        touch \${sample_id}.cnv.mod.DEL.bed
+        touch \${sample_id}.cnv.mod.DEL.vcf
+        touch \${sample_id}.cnv.mod.DUP.bed
+        touch \${sample_id}.cnv.mod.DUP.vcf
+        touch \${sample_id}.cnv.mod.vcf
+    done
+    touch ploidy-table.tsv
+
+    # Create version file as the main script does
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sample_preprocessing.py: stub
+    END_VERSIONS
+    """
+
 }

--- a/modules/local/svclustering/svclusteringdel.nf
+++ b/modules/local/svclustering/svclusteringdel.nf
@@ -37,4 +37,25 @@ process SVCLUSTERINGDEL {
         gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
     END_VERSIONS
     """
+
+    stub:
+    def dels = vcfdel.join(' ')
+    """
+    # To make this stub realist, we verify that the input file exists
+    for input_file in $dels $fasta $ploidy; do
+        if [ ! -f \$input_file ]; then
+            echo "ERROR: file \$input_file does not exist"
+            exit 1
+        fi
+    done
+    
+    # Create empty output file
+    touch ALL.MAX_CLIQUE_RO80.DEL.vcf.gz
+
+    # Create version file as the main script does
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/local/svclustering/svclusteringdup.nf
+++ b/modules/local/svclustering/svclusteringdup.nf
@@ -35,5 +35,26 @@ process SVCLUSTERINGDUP {
     "${task.process}":
         gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
     END_VERSIONS
-   """
+    """
+
+    stub:
+    def dups = vcfdup.join(' ')
+    """
+    # Verify the presence of input files to make the stub realistic
+    for input_file in $dups $fasta $ploidy; do
+        if [ ! -f \$input_file ]; then
+            echo "ERROR: file \$input_file does not exist"
+            exit 1
+        fi
+    done
+    
+    # Create an empty output file
+    touch ALL.MAX_CLIQUE_RO80.DUP.vcf.gz
+
+    # Create version file as the main script:
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/bcftools/view/environment.yml
+++ b/modules/nf-core/bcftools/view/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bcftools=1.20

--- a/modules/nf-core/bcftools/view/main.nf
+++ b/modules/nf-core/bcftools/view/main.nf
@@ -1,0 +1,76 @@
+process BCFTOOLS_VIEW {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bcftools:1.20--h8b25389_0':
+        'biocontainers/bcftools:1.20--h8b25389_0' }"
+
+    input:
+    tuple val(meta), path(vcf), path(index)
+    path(regions)
+    path(targets)
+    path(samples)
+
+    output:
+    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bcf.gz}"), emit: vcf
+    tuple val(meta), path("*.tbi")                    , emit: tbi, optional: true
+    tuple val(meta), path("*.csi")                    , emit: csi, optional: true
+    path "versions.yml"                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def regions_file  = regions ? "--regions-file ${regions}" : ""
+    def targets_file = targets ? "--targets-file ${targets}" : ""
+    def samples_file =  samples ? "--samples-file ${samples}" : ""
+    def extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf"
+    """
+    bcftools view \\
+        --output ${prefix}.${extension} \\
+        ${regions_file} \\
+        ${targets_file} \\
+        ${samples_file} \\
+        $args \\
+        --threads $task.cpus \\
+        ${vcf}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf"
+    def index = args.contains("--write-index=tbi") || args.contains("-W=tbi") ? "tbi" :
+                args.contains("--write-index=csi") || args.contains("-W=csi") ? "csi" :
+                args.contains("--write-index") || args.contains("-W") ? "csi" :
+                ""
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${index}" : ""
+
+    """
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bcftools/view/meta.yml
+++ b/modules/nf-core/bcftools/view/meta.yml
@@ -1,0 +1,88 @@
+name: bcftools_view
+description: View, subset and filter VCF or BCF files by position and filtering expression.
+  Convert between VCF and BCF
+keywords:
+  - variant calling
+  - view
+  - bcftools
+  - VCF
+tools:
+  - view:
+      description: |
+        View, subset and filter VCF or BCF files by position and filtering expression. Convert between VCF and BCF
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+      identifier: biotools:bcftools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: |
+          The vcf file to be inspected.
+          e.g. 'file.vcf'
+    - index:
+        type: file
+        description: |
+          The tab index for the VCF file to be inspected.
+          e.g. 'file.tbi'
+  - - regions:
+        type: file
+        description: |
+          Optionally, restrict the operation to regions listed in this file.
+          e.g. 'file.vcf'
+  - - targets:
+        type: file
+        description: |
+          Optionally, restrict the operation to regions listed in this file (doesn't rely upon index files)
+          e.g. 'file.vcf'
+  - - samples:
+        type: file
+        description: |
+          Optional, file of sample names to be included or excluded.
+          e.g. 'file.tsv'
+output:
+  - vcf:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{vcf,vcf.gz,bcf,bcf.gz}":
+          type: file
+          description: VCF normalized output file
+          pattern: "*.{vcf,vcf.gz,bcf,bcf.gz}"
+  - tbi:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.tbi":
+          type: file
+          description: Alternative VCF file index
+          pattern: "*.tbi"
+  - csi:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          type: file
+          description: Default VCF file index
+          pattern: "*.csi"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@abhi18av"
+maintainers:
+  - "@abhi18av"

--- a/modules/nf-core/bcftools/view/tests/main.nf.test
+++ b/modules/nf-core/bcftools/view/tests/main.nf.test
@@ -1,0 +1,298 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_VIEW"
+    script "../main.nf"
+    process "BCFTOOLS_VIEW"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/view"
+
+    test("sarscov2 - [vcf, tbi], [], [], []") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index") {
+
+        config "./vcf_gz_index.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi") {
+
+        config "./vcf_gz_index_csi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi") {
+
+        config "./vcf_gz_index_tbi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], vcf, tsv, []") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.targets.tsv.gz', checkIfExists: true)
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - stub") {
+
+        config "./nextflow.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.vcf[0][1]).name,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index - stub") {
+
+        config "./vcf_gz_index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi - stub") {
+
+        config "./vcf_gz_index_csi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi - stub") {
+
+        config "./vcf_gz_index_tbi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bcftools/view/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/view/tests/main.nf.test.snap
@@ -1,0 +1,333 @@
+{
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T12:14:38.717458272"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.tbi"
+                ]
+            ],
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T12:13:44.760671384"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T16:06:21.669668533"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T12:14:53.026083914"
+    },
+    "sarscov2 - [vcf, tbi], vcf, tsv, []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out.vcf:md5,1bcbd0eff25d316ba915d06463aab17b"
+                ]
+            ],
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T15:15:14.663512924"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - stub": {
+        "content": [
+            "out.vcf",
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T15:15:19.723448323"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T08:24:36.358469315"
+    },
+    "sarscov2 - [vcf, tbi], [], [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out.vcf:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T15:15:09.588867653"
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,241125d00357804552689c37bbabe1f5"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T12:13:33.834986869"
+    }
+}

--- a/modules/nf-core/bcftools/view/tests/nextflow.config
+++ b/modules/nf-core/bcftools/view/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = '--no-version --output-type v'
+}

--- a/modules/nf-core/bcftools/view/tests/tags.yml
+++ b/modules/nf-core/bcftools/view/tests/tags.yml
@@ -1,0 +1,2 @@
+bcftools/view:
+  - "modules/nf-core/bcftools/view/**"

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index --no-version"
+}

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index_csi.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index_csi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=csi --no-version"
+}

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index_tbi.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index_tbi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=tbi --no-version"
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,7 @@ params {
     clustering_algorithm          = 'SINGLE_LINKAGE'
     overlap                       =  0.8
     breakpoint_strategy           = 'MIN_START_MAX_END'
+    include_only_pass_variants    = true
 
     // Config options
     config_profile_name        = null
@@ -46,7 +47,6 @@ params {
     validationSchemaIgnoreParams     = 'genomes,igenomes_base'
     validationShowHiddenParams       = false
     validate_params                  = true
-
 }
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -191,8 +191,12 @@
             "MIN_START_MAX_END",
             "MAX_START_MIN_END",
             "MEAN_START_MEAN_END"
-          ],
-          "help_text": ""
+          ]
+        },
+        "include_only_pass_variants": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true (default), only consider variants for which the FILTER column is set to PASS."
         }
       }
     }

--- a/subworkflows/local/utils_nfcore_svclustering_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_svclustering_pipeline/main.nf
@@ -77,11 +77,6 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input
     Channel
     .fromSamplesheet("input")
-    .map { meta, vcf ->
-        def fnum = 1
-        [fnum, [meta.familyId] + meta.sample, meta.sample, vcf]
-    }
-    .groupTuple()  // Group by familyId
     // .view()
     .set { ch_samplesheet }
   

--- a/workflows/svclustering.nf
+++ b/workflows/svclustering.nf
@@ -9,12 +9,33 @@ include { softwareVersionsToYAML      } from '../subworkflows/nf-core/utils_nfco
 include { PREPROCESSING               } from '../modules/local/preprocessing/preprocessing.nf'
 include { SVCLUSTERINGDUP             } from '../modules/local/svclustering/svclusteringdup.nf'
 include { SVCLUSTERINGDEL             } from '../modules/local/svclustering/svclusteringdel.nf'
-
+include { BCFTOOLS_VIEW  as FILTER    } from '../modules/nf-core/bcftools/view/main.nf'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN MAIN WORKFLOW
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
+
+def groupSamples(input_ch){
+    return input_ch.map { meta, vcf ->
+        def fnum = 1
+        [fnum, [meta.familyId] + meta.sample, meta.sample, vcf]
+    }
+    .groupTuple()  // Group by familyId
+}
+
+def filterVariants(input_channel, include_only_pass_variants) {
+    if (!include_only_pass_variants) {
+        return input_channel
+    }
+    ch_filter_input =  input_channel.map{ meta, vcf -> 
+        def tbi = file(vcf + ".tbi")
+        tbi.exists() ?
+        [meta, vcf, tbi] :
+        [meta, vcf, []]
+    }
+    return FILTER(ch_filter_input, [], [], []).vcf
+}
 
 workflow SVCLUSTERING {
 
@@ -29,7 +50,11 @@ workflow SVCLUSTERING {
     //
     // MODULE: Run your modules
     //
-    PREPROCESSING(ch_samplesheet)
+
+    ch_filter_variants_output = filterVariants(ch_samplesheet, params.include_only_pass_variants)
+
+    ch_preprocessing_input = groupSamples(ch_filter_variants_output)
+    PREPROCESSING(ch_preprocessing_input)
     vcfdel = PREPROCESSING.out.vcfdel
     vcfdup = PREPROCESSING.out.vcfdup
     beddel = PREPROCESSING.out.beddel


### PR DESCRIPTION
This PR updates the pipeline to consider only variants with a FILTER column value of PASS by default.
To provide flexibility, we introduced a new parameter, `include_only_pass_variants`. This parameter allows users to disable this filtering behavior by setting it to `false`.

This change is required for the following QLIN ticket: https://ferlab-crsj.atlassian.net/browse/CLIN-3678

**Local Tests**

I built a small local dataset using data from the QA environment, keeping only positions on chromosome 22. I used a trimmed reference genome containing data only for chromosome 22.

I ran the pipeline locally with this test dataset:
```
nextflow run main.nf -profile test, docker -params-file data-test.json
```
* Observed the new filter process being executed in the command line output.
* Verified the output of the new filter process in the output directory. The filter column is always set to PASS as expected.
* Double-checked VCF files in preprocessing output folder as well. The filter column is always set to PASS as expected.
* Count the number of lines in the output files for processes svclusteringdel and svclusteringdup

I repeated the same steps using the main branch and observed variants with the FILTER status not set to PASS. There were more output in processes svclusteringdel and svclusteringdup than in the current branch, as expected.

Then, I switched back to the current branch and re-ran the pipeline with the filtering behavior turned off:
``` 
nextflow run main.nf -profile test, docker -params-file data-test/params.json --include_only_pass_variants false 
```

This time, as expected, the filter processes were not executed. I verified that the bodies of the VCF files in each process output folder were identical to those from the main branch.

**Tests in qlin etl cluster QA**

I adapted my local test setup to work on the qlin etl cluster (QA environment). The resources are copied to the following location: 
`s3://cqgc-qa-app-files-import/nextflow/test_ferlab_svclustering_pipeline/datasets/tiny_chr22`

I launched the pipeline from the nextflow long-running pod and verified that the number of lines in the final output files (del and dup) matches what I observed locally.

I then launched the pipeline again with the option `--include_only_pass_variants` false. The behavior was as expected: the filter step was skipped, and the line counts in the output files matched those observed locally on the main branch.

**Checklist**
- Pull request description: ok
- Changelog updated: ok
- README updated: ok
- Check parameter schema integrity: ok
- Run nf-core linter: ok
- Local tests: ok
- Tests in qlin: ok
- Test the stub mode is still working: ok
