### PR TITLE
BIOINFO-22 buming version to 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [v1.2] - 2024-12-17
+
 ### `Changed`
 - [#2](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/2) by default, only includes variants with FILTER column value of PASS.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -218,7 +218,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.1'
+    version         = '1.2'
     doi             = ''
 }
 


### PR DESCRIPTION
Bumping the version from 1.1. to 1.2.

Normally, nf-core recommends using the `dev` suffix in version numbers. I did not use it to stay consistent with previous behavior, as the main author of the pipeline might prefer this.