### PR TITLE
fix: CLIN-4412 filter batch script error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `Fixed`
+
+- [#7](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/7) improve error handling in view_batch process
+
 ## [v1.3] - 2025-03-06
 
 ### `Added`

--- a/modules/local/bcftools/view_batch/main.nf
+++ b/modules/local/bcftools/view_batch/main.nf
@@ -38,6 +38,7 @@ process BCFTOOLS_VIEW_BATCH {
 
     """
     #!/bin/bash
+    set -e
 
     # Initialize arrays
     input_vcfs=(${input_vcf_list.join(" ")})
@@ -77,6 +78,7 @@ process BCFTOOLS_VIEW_BATCH {
     
     """
     #!/bin/bash
+    set -e
 
     # Initialize arrays
     output_vcfs=(${output_vcf_list.join(" ")})

--- a/modules/local/bcftools/view_batch/tests/main.batch.nf.test
+++ b/modules/local/bcftools/view_batch/tests/main.batch.nf.test
@@ -139,4 +139,32 @@ nextflow_process {
             )
         }
     }
+
+    test("Small1000GenomesChr22 - with bcftools error for one file") {
+        when {
+            process {
+                """
+                meta1 = [id: "s1", prefix: 'sample_s1.test']
+                invalid_vcf_file = file(params.modules_testdata_base_path + 'vcf/NA07019.chr22.cnv.vcf.gz.tbi', checkIfExists: true)
+                meta2 = [id: "s2", prefix: 'sample_s2.test']
+                vcf_file2 = file(params.modules_testdata_base_path + 'vcf/NA07022.chr22.cnv.vcf.gz', checkIfExists: true)
+
+                input[0] = [
+                    [meta1, meta2], 
+                    [invalid_vcf_file, vcf_file2],
+                    []
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains("Failed to read from NA07019.chr22.cnv.vcf.gz.tbi: Exec format error")}
+            )
+        }
+    }
 }


### PR DESCRIPTION
This pull request addresses an issue with the FILTER_BATCH process in the ferlab-svclustering pipeline related to error handling.

Currently, if an error occurs while processing a batch of files in the FILTER_BATCH process, the script exits with a code of 0, indicating success. This behavior is misleading and could lead to unintended side effects.

We modify the FILTER_BATCH process to ensure that it exits with a non-zero code (e.g., 1) when an error occurs. This change improves error handling by immediately signaling a failure, making it easier to debug and preventing potential side effects.

**Additional Changes:**
Added a test case to validate that the process fails with a non-zero exit code when an error occurs in one of the files in the batch.

**Local tests**

✅  The fix correct the problem
- Reproduce the bug locally on the clin branch. Modify the test samplesheet so that the first file is an empty file instead of a standard VCF file. The FILTER_BATCH process should "succeed." The next process, PREPROCESSING, should fail.
- Then, run the same test command on the current branch. This time, the FILTER_BATCH process should fail with a message like this: `Failed to read from NA07019.chr22.cnv.vcf.gz: unknown file type`

✅  The fix does not change the behavior when there are no errors.
Run the pipeline locally on a small test dataset using the clin branch and the current branch:
```
nextflow run main.nf -profile test,docker -params-file data-test/params.json
```
Compare the results. There should only be minor differences (e.g., dates in headers, different order, etc.).

✅  Ensure unit tests pass
Run the following unit tests commands locally and ensure that they pass:
```
nf-test test modules/local/bcftools/view_batch/tests/main.nf.test
nf-test test modules/local/bcftools/view_batch/tests/main.batch.nf.test
```

**Juno tests**

Replicate the following local tests in juno (qa cluster)
✅  The fix correct the problem
✅  The fix does not change the behavior when there are no errors.
    - We compared only the final output files


Associated JIRA:
https://ferlab-crsj.atlassian.net/browse/CLIN-4412