### PR TITLE
Fix/clin 3816

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ nf-params.json
 
 #Work dir
 work/*
+
+# Idea files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `Changed`
+- [#9](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/9) Check PE header instead of CN when adding ECN header
+
 ## [v1.3.1] - 2025-04-23
 
 ### `Fixed`

--- a/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
+++ b/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
@@ -41,7 +41,7 @@ def process_vcf(sample_id, vcf_path):
     # Modify the VCF content
     with gzip.open(input_vcf, 'rt') if input_vcf.endswith('.gz') else open(input_vcf, 'r') as infile, open(mod_vcf, 'w') as outfile:
         for line in infile:
-            if line.startswith("##FORMAT=<ID=CN,Number=1,Type=Integer,Description=\"Estimated copy number\">"):
+            if line.startswith("##FORMAT=<ID=PE,"):
                 outfile.write(line)
                 outfile.write("##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">\n")
                 continue


### PR DESCRIPTION
## 📌 Description

Somatic CNV files in Clin do not contain the **CN** header. As a result, the **ECN** header was never added, leading to the following exception:  

```
Key ECN found in VariantContext field FORMAT
```

To fix this, we now check for the **PE** header instead of the **CN** header before adding the **ECN** header. We chose **PE** because the pipeline later relies on the **PE** metric to compute the **ECN** metric.  

Reference: https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/blob/737f56da1d095eb4a5f2fa01ba47235425f3cff6/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py#L51

## 🧪 Tests

- [x] Run the Nextflow pod in Clin on **germline files** to confirm no regression  

  <img width="477" height="134" alt="Screenshot 2025-08-26 at 11 11 56 AM" src="https://github.com/user-attachments/assets/ea3400f8-5adc-4f14-bfaa-6e4a9bce4204" />

- [x] Run the Nextflow pod in Clin on **somatic files** to confirm the issue is fixed  

  <img width="477" height="134" alt="Screenshot 2025-08-26 at 11 04 44 AM" src="https://github.com/user-attachments/assets/e12810b2-fe1f-47e3-9abe-6bd306751b70" />

## 🗂️ Miscellaneous

- Added `.idea` files to `.gitignore`
