### PR TITLE
Feat/clin 5357 dragen 4.4 relax metric order in format column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.3.3] - 2025-11-18
+- [#11](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull///) Relax metric order assumptions in format column
+
 ## [v1.3.2] - 2025-08-26
 
 ### `Changed`

--- a/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
+++ b/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
@@ -8,6 +8,8 @@ import sys
 
 VERSION = "1.0"
 
+FORMAT_COLUMN_IDX = 8 # 0-based index of the FORMAT column in VCF
+
 def create_ploidy_table(samples):
     """
     Creates a ploidy table with chromosome names and sample IDs.
@@ -46,9 +48,25 @@ def process_vcf(sample_id, vcf_path):
                 outfile.write("##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">\n")
                 continue
             elif not line.startswith("#"):
+                # Insert INFO field ALGORITHMS
                 line = re.sub(r";END", ";ALGORITHMS=depth;END", line)
-                line = re.sub(r":PE", ":PE:ECN", line)
-                line = line.strip() + ":2\n"
+
+                # Insert ECN just after PE in FORMAT column
+                cols = line.strip().split('\t')
+                format_col = cols[FORMAT_COLUMN_IDX]
+                format_fields = format_col.split(':')
+                ecn_index = format_fields.index("PE") + 1
+                format_fields.insert(ecn_index, "ECN")
+                cols[FORMAT_COLUMN_IDX] = ':'.join(format_fields)
+
+                # Insert ECN metric just after PE metric in each sample column
+                # Just in case, supporting multi-sample, but our use case is single-sample VCFs
+                for i in range(FORMAT_COLUMN_IDX + 1, len(cols)):
+                    sample_values = cols[i].split(':')
+                    sample_values.insert(ecn_index, "2")
+                    cols[i] = ':'.join(sample_values)
+                
+                line = '\t'.join(cols) + '\n'
             outfile.write(line)
 
     # Extract DUP and DEL variants

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.3.2'
+    version         = '1.3.3'
     doi             = ''
 }
 


### PR DESCRIPTION
Dragen 4.4 VCFs include the PE metric in the FORMAT column, but not necessarily at the end as previously assumed.

This PR relaxes the rigid assumption about the position of PE in the FORMAT and sample columns, ensuring compatibility with Dragen 4.4 VCFs.

**Local test:**
- Run the pipeline locally with docker executor on our test public dataset. Check that the output of the preprocessing process is identical to previous version.
- run nf-core lint on qlin branch and this one and check there are no extra warning introduced: ok
 Note: There are new warnings about nf-core module code being out of sync. We should address this eventually, but for now, we avoid making unnecessary changes.

**Integration test**
The pipeline was run successfully on dragen 4.4 data, in clin
