### PR TITLE
CLIN-5347 ensure output filenames reflect configured algorithm and reciprocal overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.3.4] - 2025-11-25
+
+### `Changed`
+- [#12](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/12) output filenames now dynamically reflect the clustering algorithm and reciprocal overlap threshold
+
 ## [v1.3.3] - 2025-11-18
-- [#11](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull///) Relax metric order assumptions in format column
+
+### `Changed`
+- [#11](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/11) Relax metric order assumptions in format column
 
 ## [v1.3.2] - 2025-08-26
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -27,10 +27,19 @@ Below, you can see the structure of the output directory. The subfolders `filter
     - ${sample}.cnv.mod.(DEL/DUP).bed
     - ploidy_table.tsv
   - `svclusteringdup/`
-    - ALL.MAX_CLIQUE_RO80.DUP.vcf.gz : The vcf with CNV DUP cluster for all samples
+    - ALL.SINGLE_LINKAGE_RO80.DUP.vcf.gz : The vcf with CNV DUP cluster for all samples
   - `svclusteringdel/`
-    - ALL.MAX_CLIQUE_RO80.DEL.vcf.gz : The vcf with CNV DEL cluster for all samples
+    - ALL.SINGLE_LINKAGE_RO80.DEL.vcf.gz : The vcf with CNV DEL cluster for all samples
 
 </details>
 
 [Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.
+
+### Output file naming
+
+The filenames for the DUP/DEL cluster files will follow this pattern: 
+"ALL.`${clustering_algorithm}`_RO`${reciprocal_overlap_in_percent}`.`${variant_type}`.vcf.gz"
+
+For example:
+- `ALL.SINGLE_LINKAGE_RO80.DEL.vcf.gz`
+- `ALL.SINGLE_LINKAGE_RO80.DUP.vcf.gz`

--- a/modules/local/svclustering/svclusteringdel.nf
+++ b/modules/local/svclustering/svclusteringdel.nf
@@ -25,8 +25,9 @@ process SVCLUSTERINGDEL {
     def clustering_algorithm = params.clustering_algorithm
     def overlap              = params.overlap
     def breakpoint_strategy  = params.breakpoint_strategy
+    def output_file          = "ALL.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DEL.vcf.gz"
     """
-    gatk SVCluster --output ALL.MAX_CLIQUE_RO80.DEL.vcf.gz -V $dels \
+    gatk SVCluster --output $output_file -V $dels \
      --ploidy-table $ploidy --algorithm $clustering_algorithm \
      --reference $fasta --depth-interval-overlap $overlap \
      --breakpoint-summary-strategy $breakpoint_strategy \
@@ -40,6 +41,9 @@ process SVCLUSTERINGDEL {
 
     stub:
     def dels = vcfdel.join(' ')
+    def clustering_algorithm = params.clustering_algorithm
+    def overlap              = params.overlap
+    def output_file          = "ALL.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DEL.vcf.gz"
     """
     # To make this stub realist, we verify that the input file exists
     for input_file in $dels $fasta $ploidy; do
@@ -50,7 +54,7 @@ process SVCLUSTERINGDEL {
     done
     
     # Create empty output file
-    touch ALL.MAX_CLIQUE_RO80.DEL.vcf.gz
+    touch ${output_file}
 
     # Create version file as the main script does
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/svclustering/svclusteringdup.nf
+++ b/modules/local/svclustering/svclusteringdup.nf
@@ -24,8 +24,9 @@ process SVCLUSTERINGDUP {
     def clustering_algorithm = params.clustering_algorithm
     def overlap              = params.overlap
     def breakpoint_strategy  = params.breakpoint_strategy
+    def output_file          = "ALL.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DUP.vcf.gz"
     """
-    gatk SVCluster --output ALL.MAX_CLIQUE_RO80.DUP.vcf.gz -V $dups \
+    gatk SVCluster --output $output_file -V $dups \
      --ploidy-table $ploidy --algorithm $clustering_algorithm \
      --reference $fasta --depth-interval-overlap $overlap \
      --breakpoint-summary-strategy $breakpoint_strategy \
@@ -39,6 +40,10 @@ process SVCLUSTERINGDUP {
 
     stub:
     def dups = vcfdup.join(' ')
+    def clustering_algorithm = params.clustering_algorithm
+    def overlap              = params.overlap
+    def output_file          = "ALL.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DUP.vcf.gz"
+   
     """
     # Verify the presence of input files to make the stub realistic
     for input_file in $dups $fasta $ploidy; do
@@ -49,7 +54,7 @@ process SVCLUSTERINGDUP {
     done
     
     # Create an empty output file
-    touch ALL.MAX_CLIQUE_RO80.DUP.vcf.gz
+    touch ${output_file}
 
     # Create version file as the main script:
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.3.3'
+    version         = '1.3.4'
     doi             = ''
 }
 


### PR DESCRIPTION
# CLIN-5347 ensure output filenames reflect configured algorithm and reciprocal overlap

## 📌 Context

Previously, the DUP/DEL cluster output filenames included the hardcoded tag "MAX_CLIQUE_RO80", even though the default algorithm is SINGLE_LINKAGE and users may specify different options when running the pipeline. To avoid misleading filenames, the output files are now named dynamically based on the configured clustering algorithm and reciprocal overlap threshold.

## 📝 Changes

- Updated local processes SVCLUSTERINGDUP and SVCLUSTERINGDEL to dynamically generate output filenames based on the configured clustering algorithm and reciprocal overlap threshold
- Updated the documentation
- Bump version and update changelog

## ☑️ TO-DOs


## 🧪 Tests

We ran the pipeline locally on a small public dataset using the following parameter combinations:

- Default parameters
- Default parameters with `-stub`
- with `--clustering_algorithm=MAX_CLIQUE --overlap=0.9`
- with `--clustering_algorithm=MAX_CLIQUE --overlap=0.9 -stub`

For each run, we verified that the output filenames matched the expected pattern

For the run with default parameters, we check that the output file content did not change in comparison to results obtained from the clin branch.

Run the nf-test command locally and make sure all tests pass

Check that there are no new linter warning appear compared to the clin branch.

## 🔗 Related Issues

https://ferlab-crsj.atlassian.net/browse/CLIN-5347