### PR TITLE
fix: CLIN-5567 fix bug in INFO field parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.3.5] - 2026-01-23
+
+### `Fixed`
+- [#13](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering/pull/13) Fix ALGORITHMS not being added to INFO field when column starts with END.
+
 ## [v1.3.4] - 2025-11-25
 
 ### `Changed`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ nextflow pull ferlab/svclustering
 
 It is a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [ferlab/svclustering releases page](https://github.com/ferlab/svclustering/releases) and find the latest pipeline version - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`. Of course, you can switch to another version by changing the number after the `-r` flag.
+First, go to the [ferlab/svclustering releases page](https://github.com/ferlab/svclustering/releases) and find the latest pipeline version - numeric only (eg. `1.3.5`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.5`. Of course, you can switch to another version by changing the number after the `-r` flag.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
 

--- a/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
+++ b/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
@@ -6,8 +6,9 @@ import os
 import re
 import sys
 
-VERSION = "1.0"
+VERSION = "1.3"
 
+INFO_COLUMN_IDX = 7   # 0-based index of the INFO column in VCF
 FORMAT_COLUMN_IDX = 8 # 0-based index of the FORMAT column in VCF
 
 def create_ploidy_table(samples):
@@ -48,11 +49,13 @@ def process_vcf(sample_id, vcf_path):
                 outfile.write("##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">\n")
                 continue
             elif not line.startswith("#"):
+                cols = line.strip().split('\t')
+
                 # Insert INFO field ALGORITHMS
-                line = re.sub(r";END", ";ALGORITHMS=depth;END", line)
+                info_col = cols[INFO_COLUMN_IDX]
+                cols[INFO_COLUMN_IDX] = "ALGORITHMS=depth;" + info_col
 
                 # Insert ECN just after PE in FORMAT column
-                cols = line.strip().split('\t')
                 format_col = cols[FORMAT_COLUMN_IDX]
                 format_fields = format_col.split(':')
                 ecn_index = format_fields.index("PE") + 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.3.4'
+    version         = '1.3.5'
     doi             = ''
 }
 


### PR DESCRIPTION
Regex to add the ALGORITHM field in INFO depended on END not being the first field (;END). 
Fixed it so that adding the algorithm information does not depend on another field. 
 
Tested in cqgc-qa nextflow troubleshooting pod with somatic samplesheet (which triggered the error), and germline samplesheet. 
